### PR TITLE
Fix base64-decoding of non-ASCII text

### DIFF
--- a/hasher.py
+++ b/hasher.py
@@ -48,7 +48,7 @@ class Base64DecodeCommand(sublime_plugin.TextCommand):
 				s = self.view.word(s)
 
 			selected = self.view.substr(s)
-			txt = base64.b64decode(selected)
+			txt = base64.b64decode(selected).decode('utf-8')
 			self.view.replace(edit, s, txt)
 
 class UriComponentEncodeCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Hello. Since b64decode returns a string object, not a unicode object, it's important to decode() it. Otherwise you'll get a famous "ascii codec could not decode bla-bla" error if you try to b64decode a text containing non-ASCII letters, as it happened to me (just to mention, under Windows). People on StackOverflow say you should always decode to utf-8: http://stackoverflow.com/questions/305140#comment-3279047
